### PR TITLE
feat: assign label to all files in the .github dir

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 ci/cd:
-  - .github/workflows/*
+  - .github/**
 
 infrastructure:
   - terraform/**


### PR DESCRIPTION
### Description
What: All files under `.github/` should be labeled as CICD. Currently it is only taking files under `.github/workflows` into consideration. 

How: By updating `labeler.yml` 

Link to Jira Ticket: n.a.

---

### Code Checklist
- [ ] tested
- [ ] documented
