### PR TITLE
chore(codeowners): set CODEOWNERS to @GifhornerFriedenskirche/ci-cd

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/github @GifhornerFriedenskirche/ci-cd
+/.github @GifhornerFriedenskirche/ci-cd

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.github @bjornvandijkman-ingka
+/github @GifhornerFriedenskirche/ci-cd


### PR DESCRIPTION
# What
Update CODEOWNERS to assign the .github directory to the GifhornerFriedenskirche ci-cd team.

# Why
Ensure automatic reviewer requests and code-owner awareness are routed to the ci-cd team.

# Notes
The ci-cd team must have repository access for auto-requested reviews to work; branch-protection settings may block direct merges.
